### PR TITLE
Fixed an issue with triple quoutes, such that a closing single quote …

### DIFF
--- a/scala/syntaxes/scala.tmLanguage
+++ b/scala/syntaxes/scala.tmLanguage
@@ -558,7 +558,7 @@
 					<key>begin</key>
 					<string>"""</string>
 					<key>end</key>
-					<string>"""</string>
+					<string>"{3,}</string>
 					<key>name</key>
 					<string>string.quoted.triple.scala</string>
 				</dict>

--- a/scala/syntaxes/scala.tmLanguage
+++ b/scala/syntaxes/scala.tmLanguage
@@ -564,6 +564,45 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>s"""</string>
+					<key>end</key>
+					<string>"{3,}</string>
+					<key>name</key>
+					<string>string.quoted.triple.scala</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>\$([a-zA-Z$_][a-zA-Z0-9$_]*)\s*</string>
+							<key>name</key>
+							<string>variable.name</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>variable.name</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>string.quoted.triple.scala</string>
+								</dict>
+								<key>3</key>
+								<dict>
+									<key>name</key>
+									<string>variable.name</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(\${)([a-zA-Z$_][a-zA-Z0-9$_]*)(})\s*</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>(?&lt;!\\)"</string>
 					<key>end</key>
 					<string>"</string>
@@ -582,6 +621,48 @@
 							<string>\\.</string>
 							<key>name</key>
 							<string>constant.character.escape.scala</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\\$
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?&lt;!\\)s"</string>
+					<key>end</key>
+					<string>"</string>
+					<key>name</key>
+					<string>string.quoted.double.scala</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>\$([a-zA-Z$_][a-zA-Z0-9$_]*)\s*</string>
+							<key>name</key>
+							<string>variable.name</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>variable.name</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>string.quoted.double.scala</string>
+								</dict>
+								<key>3</key>
+								<dict>
+									<key>name</key>
+									<string>variable.name</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(\${)([a-zA-Z$_][a-zA-Z0-9$_]*)(})\s*</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
A closing single quote followed by a closing triple quote would be captured correctly.

Test with this string:

```
val str = """the boy said "follow me!""""
//This should not be highlighted!
```

Essentially in the current version on the main repo, in the above code, the commented line (and all lines below it) would be highlighted as if they were within the string.
