### PR TITLE
Fix Scala imports highlight issue

### DIFF
--- a/scala/syntaxes/scala.tmLanguage
+++ b/scala/syntaxes/scala.tmLanguage
@@ -352,7 +352,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?&lt;=[\n;])</string>
+			<string>((\w|\.)+)_*;*</string>
 			<key>name</key>
 			<string>meta.import.scala</string>
 			<key>patterns</key>


### PR DESCRIPTION
This fixes an issue with import statements when not adding ";" misses up the next import lines

Before:
<img width="359" alt="screen shot 2016-06-22 at 12 10 27" src="https://cloud.githubusercontent.com/assets/1384456/16263006/6662877c-3872-11e6-966b-147eb3eaaaf9.png">

After:
<img width="383" alt="screen shot 2016-06-22 at 12 09 53" src="https://cloud.githubusercontent.com/assets/1384456/16263011/6a55cb00-3872-11e6-8e7e-6a8260d980c8.png">
